### PR TITLE
Fixed bug with NSArray getting mutated while being enumerated

### DIFF
--- a/SoundManager/SoundManager.m
+++ b/SoundManager/SoundManager.m
@@ -547,7 +547,7 @@ NSString *const SoundDidFinishPlayingNotification = @"SoundDidFinishPlayingNotif
 
 - (void)stopAllSounds:(BOOL)fadeOut
 {
-    for (Sound *sound in currentSounds)
+    for (Sound *sound in [currentSounds reverseObjectEnumerator])
     {
         [self stopSound:sound fadeOut:YES];
     }


### PR DESCRIPTION
Hi Nick,
There's a bug in the stopAllSounds:fadeOut: method. You iterate currentSounds and then call stopSound:fadeOut: which internally does delete some object in currentSounds, causing the exception. I was about to create a temporary copy of the array, but then I had a look at your code and discovered that reverseObjectEnumerator can fix the problem in a more elegant way... so I used it.
